### PR TITLE
Kotlin poet port of @transformative

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.7.10"
 kspVersion = "1.7.10-1.0.6"
+kotlinPoet = "1.12.0"
 kotlinCompileTesting = "1.4.9"
 assertj = "3.23.1"
 classgraph = "4.8.147"
@@ -8,6 +9,8 @@ classgraph = "4.8.147"
 [libraries]
 kotlin-stdlibCommon = { module = "org.jetbrains.kotlin:kotlin-stdlib-common" }
 kotlin-stdlibJDK8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
+kotlinPoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "kspVersion" }
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
 kotlinCompileTestingKsp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "kotlinCompileTesting" }

--- a/ksp/build.gradle.kts
+++ b/ksp/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }

--- a/ksp/build.gradle.kts
+++ b/ksp/build.gradle.kts
@@ -12,6 +12,8 @@ kotlin {
 
 dependencies {
     implementation(libs.kotlin.stdlibJDK8)
+    implementation(libs.kotlinPoet)
+    implementation(libs.kotlinPoet.ksp)
     implementation(libs.ksp)
 
     testImplementation(kotlin("test"))

--- a/ksp/src/main/kotlin/fp/serrano/transformative/KotlinPoetExtensions.kt
+++ b/ksp/src/main/kotlin/fp/serrano/transformative/KotlinPoetExtensions.kt
@@ -1,0 +1,29 @@
+package fp.serrano.transformative
+
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+
+fun FileSpec.Builder.addFunction(
+  name: String,
+  receiver: TypeName? = null,
+  returns: TypeName? = null,
+  typeVariables: Iterable<TypeVariableName> = emptyList(),
+  block: FunSpec.Builder.() -> Unit = {},
+) {
+  addFunction(FunSpec.builder(name).apply {
+    receiver?.apply { receiver(receiver) }
+    returns?.apply { returns(returns) }
+    addTypeVariables(typeVariables)
+  }.apply(block).build())
+}
+
+fun Map<String, String>.test() {
+  this.map { }
+}
+
+fun buildFile(packageName: String, fileName: String, block: FileSpec.Builder.() -> Unit): FileSpec =
+  FileSpec.builder(packageName, fileName).apply(block).build()
+
+fun ClassName.parameterizedWhenNotEmpty(
+  typeArguments: List<TypeName>
+): TypeName = takeIf { typeArguments.isNotEmpty() }?.parameterizedBy(typeArguments) ?: this

--- a/types/build.gradle.kts
+++ b/types/build.gradle.kts
@@ -1,7 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.kotlin.jvm)
+}
+
+kotlin {
+    explicitApi()
 }
 
 tasks.withType<KotlinCompile> {

--- a/types/src/main/kotlin/fp/serrano/Transformative.kt
+++ b/types/src/main/kotlin/fp/serrano/Transformative.kt
@@ -2,4 +2,4 @@ package fp.serrano
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
-annotation class transformative
+public annotation class transformative


### PR DESCRIPTION
Apples to apples conversion of the current implementation of the Tranformative processor to use Kotlin Poet. 

There is some duplication from #1 but we can deal with it once either of these PRs are merged :crossed\_fingers: